### PR TITLE
Hotfix/post style

### DIFF
--- a/src/Post.css
+++ b/src/Post.css
@@ -93,6 +93,6 @@
 /* Media Query Breakpoint for Tablets in Portrait Mode (768px+) */
 @media only screen and (min-width: 48em) {
   .Overlay-Text {
-    padding: 70px;
+    padding: 80px;
   }
 }


### PR DESCRIPTION
I added some responsive padding for the overloay text of the posts. Since it get's more centered on bigger screens, it is easier to read.

Instead of that on desktop:
<img width="1680" alt="Bildschirmfoto 2019-12-19 um 15 59 08" src="https://user-images.githubusercontent.com/45079854/71184355-ed8c3f00-2279-11ea-9fac-6101371254eb.png">
 
And this on standard mobile devices:
<img width="402" alt="Bildschirmfoto 2019-12-19 um 16 11 13" src="https://user-images.githubusercontent.com/45079854/71184622-54a9f380-227a-11ea-92cd-937120bf2564.png">



It would look like that:
<img width="1680" alt="Bildschirmfoto 2019-12-19 um 16 07 14" src="https://user-images.githubusercontent.com/45079854/71184373-f7ae3d80-2279-11ea-9ceb-0464336a27fa.png">

And that:

<img width="402" alt="Bildschirmfoto 2019-12-19 um 16 11 27" src="https://user-images.githubusercontent.com/45079854/71184647-5e335b80-227a-11ea-8ec0-8c4b56a59c22.png">

Hope, you guys like it!
